### PR TITLE
Create NuGet packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,51 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - master
+      - rel
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        submodules: 'true'
+
+    - name: Setup .NET Core 5.0.102
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 5.0.102
+
+    - name: Determine semantic version
+      uses: dotnet/nbgv@master
+      id: nbgv
+      with:
+        path: dotnet
+
+    - name: Build
+      run: dotnet build dotnet/dotnet.sln --configuration Release -p:PackageVersion=${{ steps.nbgv.outputs.SemVer2 }}
+
+    # Uncomment to push to Github packages on a CI build from master.
+    #- name: Push NuGet packages to GitHub packages
+    #  if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+    #  run: dotnet nuget push **/*.nupkg
+    #    --source https://nuget.pkg.github.com/cyberphone/index.json
+    #    --api-key ${{ secrets.GITHUB_TOKEN }}
+    #    --no-symbols true
+    #    --skip-duplicate
+
+    # Uncomment to push to NuGet on a build from 'rel'
+    #- name: Push NuGet packages to NuGet.org
+    #  if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/rel' }}
+    #  run: dotnet nuget push **/*.nupkg
+    #    --source https://api.nuget.org/v3/index.json
+    #    --api-key ${{ secrets.NUGET_KEY }}
+    #    --no-symbols true
+    #    --skip-duplicate

--- a/dotnet/es6numberserializer/es6numberserializer.csproj
+++ b/dotnet/es6numberserializer/es6numberserializer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/dotnet/es6numberserializer/es6numberserializer.csproj
+++ b/dotnet/es6numberserializer/es6numberserializer.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
 </Project>

--- a/dotnet/jsoncanonicalizer/jsoncanonicalizer.csproj
+++ b/dotnet/jsoncanonicalizer/jsoncanonicalizer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/dotnet/jsoncanonicalizer/jsoncanonicalizer.csproj
+++ b/dotnet/jsoncanonicalizer/jsoncanonicalizer.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/dotnet/version.json
+++ b/dotnet/version.json
@@ -1,0 +1,6 @@
+{
+  "version": "1.0",
+  "publicReleaseRefSpec": [
+    "^refs/heads/rel$"
+  ],
+}


### PR DESCRIPTION
Fixes #8.

This PR changes the target framework of the two libraries to the broader netstandard2.0 (instead of .netcore 3.1).
It adds a version.json that will be leveraged by Nerdbank.Gitversioning to determine a version number.
It adds a Github Actions workflow that will build nuget packages and push them to Github packages/Nuget.

To push to Nuget.org, you will need to generate an access token on Nuget.org and store it in this project's secret settings as NUGET_KEY. 